### PR TITLE
Use the toolchain

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 3
   script:
     # FIXME: This is a hack to make sure the environment is activated.
     # The reason this is required is due to the conda-build issue

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,10 +14,19 @@ source:
 build:
   skip: true  # [win]
   number: 2
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script:
+    # FIXME: This is a hack to make sure the environment is activated.
+    # The reason this is required is due to the conda-build issue
+    # mentioned below.
+    #
+    # https://github.com/conda/conda-build/issues/910
+    #
+    - source activate "${CONDA_DEFAULT_ENV}"  # [unix]
+    - python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
+    - toolchain
     - boost 1.61.*
     - python
     - setuptools >=18.0


### PR DESCRIPTION
This was previously linked to `libstdc++` on Mac. However, as it links to `boost`, which use `libc++` on Mac, this may cause issues. While this actually hasn't bit us yet, it is probably time we switch this over just to avoid any potential issues.
