### PR TITLE
Release 0.4.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rank_filter" %}
-{% set version = "0.4.12" %}
-{% set checksum = "a55775639a2763747c7e7d48178836c69cab776cb6cf675f6063cca27c2093d5" %}
+{% set version = "0.4.13" %}
+{% set checksum = "cf5cffa85bc0c4b8d716938d08bfe8af9e7e3fe81bf7af2a3a6e0e2675d083e2" %}
 
 package:
   name: {{ name }}
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 2
+  number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -33,8 +33,14 @@ requirements:
     - numpy >=1.7
 
 test:
+  source_files:
+    - tests
+
   imports:
     - rank_filter
+
+  commands:
+    - python -m unittest discover -s .
 
 about:
   home: https://github.com/nanshe-org/rank_filter


### PR DESCRIPTION
```markdown
### v0.4.13

* Group CI matrix by Python version. #91
* Fix linkage to vigranumpy on Mac. #89
* Detect Python library name. #88
* Tidy up Python inspection. #87
* Fix Mac build. #85
* Drop `.cpp` from our globbed sources. #84
* Update manifest. #83
* Add Python 3.6 to Travis CI's matrix. #82
* NumPy 1.11, 1.12 matrix. #77
* Rename directory `test` to `tests`. #81
* Drop cleanup step from `conda-build` recipe. #80
* CMake test cleanup. #79
* Fix recipe tests. #78
* Specify the Python version to build against on Travis. #76
* License 2017. #74
* Fix CI build. #75
* Import `setuptools` before `distutils`. #71
```

Note: Now runs the tests as they are packaged in the `sdist`.