### PR TITLE
Use boost-cpp

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   build:
     - toolchain
-    - boost 1.64.*
+    - boost-cpp 1.64.*
     - python
     - setuptools >=18.0
     - numpy x.x
@@ -27,7 +27,7 @@ requirements:
     - cython >=0.23
 
   run:
-    - boost 1.64.*
+    - boost-cpp 1.64.*
     - python
     - numpy x.x
     - numpy >=1.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
This package only needs a handful of C++ headers and one C++ library from Boost to build. None of which actually use Python. Nor does this package use Boost.Python. So it makes sense to switch to the lighter weight `boost-cpp` package to drop the Python and NumPy parts of Boost that this does not use.