### PR TITLE
Use new NumPy pinnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,10 @@
 version: 2
 
 jobs:
-  build__CONDA_NPY_111__CONDA_PY_27:
+  build__CONDA_PY_27:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_NPY: "111"
       - CONDA_PY: "27"
     steps:
       - checkout
@@ -19,62 +18,14 @@ jobs:
       - run:
           name: Print conda-build environment variables
           command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
             echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_112__CONDA_PY_27:
+  build__CONDA_PY_35:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_NPY: "112"
-      - CONDA_PY: "27"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_113__CONDA_PY_27:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "113"
-      - CONDA_PY: "27"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_111__CONDA_PY_35:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "111"
       - CONDA_PY: "35"
     steps:
       - checkout
@@ -88,62 +39,14 @@ jobs:
       - run:
           name: Print conda-build environment variables
           command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
             echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
           command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_112__CONDA_PY_35:
+  build__CONDA_PY_36:
     working_directory: ~/test
     machine: true
     environment:
-      - CONDA_NPY: "112"
-      - CONDA_PY: "35"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_113__CONDA_PY_35:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "113"
-      - CONDA_PY: "35"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_111__CONDA_PY_36:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "111"
       - CONDA_PY: "36"
     steps:
       - checkout
@@ -157,53 +60,6 @@ jobs:
       - run:
           name: Print conda-build environment variables
           command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_112__CONDA_PY_36:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "112"
-      - CONDA_PY: "36"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
-            echo "CONDA_PY=${CONDA_PY}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
-  build__CONDA_NPY_113__CONDA_PY_36:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_NPY: "113"
-      - CONDA_PY: "36"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_NPY=${CONDA_NPY}"
             echo "CONDA_PY=${CONDA_PY}"
       - run:
           # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
@@ -213,12 +69,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build__CONDA_NPY_111__CONDA_PY_27
-      - build__CONDA_NPY_112__CONDA_PY_27
-      - build__CONDA_NPY_113__CONDA_PY_27
-      - build__CONDA_NPY_111__CONDA_PY_35
-      - build__CONDA_NPY_112__CONDA_PY_35
-      - build__CONDA_NPY_113__CONDA_PY_35
-      - build__CONDA_NPY_111__CONDA_PY_36
-      - build__CONDA_NPY_112__CONDA_PY_36
-      - build__CONDA_NPY_113__CONDA_PY_36
+      - build__CONDA_PY_27
+      - build__CONDA_PY_35
+      - build__CONDA_PY_36

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,9 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=112  CONDA_PY=27
-    - CONDA_NPY=113  CONDA_PY=27
-    - CONDA_NPY=111  CONDA_PY=35
-    - CONDA_NPY=112  CONDA_PY=35
-    - CONDA_NPY=113  CONDA_PY=35
-    - CONDA_NPY=111  CONDA_PY=36
-    - CONDA_NPY=112  CONDA_PY=36
-    - CONDA_NPY=113  CONDA_PY=36
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "oDenpZeZvvu36OJInRkMkXHzFZCmAfegFk7HqWoquxbNry8v/NBzbRJpBFXhHDwubeqoa7ewwwflQsLe5daS4wX3tanHpnXe423E9P0Bpjt1jPWqTbQiTE2nfSJUuMvgN09i06MuvuXMNtqhVjE6gflo9HkZCBa2K9fMg+fQQyqWfPSj2OQPJH4TroqjumeiyUPBVBj7Hp+3u2s24btRSpW/D0glSvkbcOOuQrR7YHzMSd8aP0itc/YgDgU+0MIFBkefWEzbWVC42T37zbEtIcvFo0Q/xUBH+m5cidFULP0ARmprCedLuF7F77N4bhfuNix/TIYnT8JXnRPBOLjr3AY9KBnkJm8MRazuOgAxXxksKYPenJfyffKk/mFKHKdRgB5URm8hLJhg2tWXrZOFyXDv6UzS2iecDJbIEzkNHRYzkDQm2ygZFId68cDNYC+6YeAxuHTz2d3sZTgugN7YAZCW3/zhDBk+7sfKRT67zgBb17vIsAuuon4hdCDYNZYYUl4t09Pi4BFmZdESxb0y4XOQHP/2fy4cH8fGmo2SLS4KuLZ97LltW5sBYO3urb9fh30Tvi7qNFrcTs2zPU6dt504pq5bRg/P5z3ykbtmpmO3KBZ4fKT8a8NXufUMy3zUa+/9lcfLw2mnYmwoKsuLsCBdovA+Ysu/QJ/1ktgcm/o="

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,92 +10,26 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_NPY: 112
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 113
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 111
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x86
-      CONDA_NPY: 112
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 113
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 111
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 112
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 113
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -40,7 +40,6 @@ cat << EOF | docker run -i \
                         -v "${RECIPE_ROOT}":/recipe_root \
                         -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -e HOST_USER_ID="${HOST_USER_ID}" \
-                        -e CONDA_NPY="${CONDA_NPY}" \
                         -e CONDA_PY="${CONDA_PY}" \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,15 +21,17 @@ requirements:
     - boost-cpp 1.64.*
     - python
     - setuptools >=18.0
-    - numpy x.x
-    - numpy >=1.7
+    - numpy 1.8.*  # [not (win and (py35 or py36))]
+    - numpy 1.9.*  # [win and py35]
+    - numpy 1.11.*  # [win and py36]
     - cython >=0.23
 
   run:
     - boost-cpp 1.64.*
     - python
-    - numpy x.x
-    - numpy >=1.7
+    - numpy >=1.8  # [not (win and (py35 or py36))]
+    - numpy >=1.9  # [win and py35]
+    - numpy >=1.11  # [win and py36]
 
 test:
   source_files:


### PR DESCRIPTION
Update this feedstock to use the [new style of NumPy pinnings in conda-forge]( https://conda-forge.org/docs/meta.html#building-against-numpy ). This should cutdown on the CI resources this feedstock uses and allow the deployed packages to be used with older versions of NumPy if needed. Also re-render to take advantage of the new CircleCI matrix and eliminate the NumPy CI matrices (as they are unneeded with the new NumPy pinnings).