### PR TITLE
Pin boost to 1.65.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   build:
     - toolchain
-    - boost-cpp 1.64.*
+    - boost-cpp 1.65.1
     - python
     - setuptools >=18.0
     - numpy 1.8.*  # [not (win and (py35 or py36))]
@@ -27,7 +27,7 @@ requirements:
     - cython >=0.23
 
   run:
-    - boost-cpp 1.64.*
+    - boost-cpp 1.65.1
     - python
     - numpy >=1.8  # [not (win and (py35 or py36))]
     - numpy >=1.9  # [win and py35]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
Update boost pinning to 1.65.1 and rebuild with a new build number.