### PR TITLE
Release 0.4.15

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,24 +51,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "rank_filter" %}
-{% set version = "0.4.14" %}
-{% set checksum = "617dddeb32d1a084fa125dc371a5c0337be8d164f5fc16b6dbe48284dd5282dc" %}
+{% set version = "0.4.15" %}
+{% set checksum = "e5a3c6eb3a1c23e7a522221b54a7f96b5c38d4e47a4adf461c073f0ddacbf3d5" %}
 
 package:
   name: {{ name }}
@@ -12,13 +12,13 @@ source:
   sha256: {{ checksum }}
 
 build:
-  number: 2
+  number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:
     - toolchain
-    - boost-cpp 1.65.1
+    - boost-cpp 1.66.0
     - python
     - setuptools >=18.0
     - numpy 1.8.*  # [not (win and (py35 or py36))]
@@ -27,7 +27,7 @@ requirements:
     - cython >=0.23
 
   run:
-    - boost-cpp 1.65.1
+    - boost-cpp 1.66.0
     - python
     - numpy >=1.8  # [not (win and (py35 or py36))]
     - numpy >=1.9  # [win and py35]


### PR DESCRIPTION
```markdown
# v0.4.15

* Fixes some issues with newer conda-forge packages and simplifies CI. #115
* Require the VIGRA tests pass on Travis CI. #116
* More trove classifiers and conda-forge badge. #117
```